### PR TITLE
Post Type Block: Resolve block invisibility in iframed editor

### DIFF
--- a/src/util/isRenderedInEditor.js
+++ b/src/util/isRenderedInEditor.js
@@ -5,11 +5,17 @@
  * @returns {boolean}
  */
 const isRenderedInEditor = element => {
-  if (!element) {
+  if (!element || 'undefined' === typeof window) {
     return false;
   }
 
-  return !!element.closest?.('.block-editor-writing-flow');
+  return !!(
+    element.closest?.('.block-editor-writing-flow') ||
+    element.closest?.('.is-root-container') ||
+    element.ownerDocument?.body?.classList?.contains?.(
+      'block-editor-iframe__body',
+    )
+  );
 };
 
 export default isRenderedInEditor;


### PR DESCRIPTION
closes #19 

This PR fixes an issue where the Post Type block fails to render in modern versions of the Gutenberg plugin (22.6+). The block was appearing invisible because the environment detection logic could not "see" the editor container when isolated inside the new content iframe.

In legacy WordPress environments, the entire editor lived in a single window. The `isRenderedInEditor` utility checked for the `.block-editor-writing-flow` class to confirm it was safe to render editor-only UI.
With the introduction of the Iframed Editor, the block is rendered inside a separate `<iframe>` where the check fails.

### Fix
The utility has been updated to be "iframe-aware" while maintaining full backward compatibility.

### Testing
#### Modern Gutenberg (Bleeding Edge)
- Install and activate the Gutenberg Plugin (v22.6.0).
- Create a new Post.
- Insert the Post Type block.
- Verify: The block preview should load, and the Inspector Controls should be visible.

#### Legacy/Stable WordPress
- Use a standard WordPress install (v6.9.1) without the Gutenberg plugin.
- Insert the Post Type block.
- Verify: The block should render exactly as it did previously, confirming no regressions.


https://github.com/user-attachments/assets/db09e78f-972b-4d8f-815b-1d3082cba24f


PS - Correct me if I'm wrong, but the `isRenderedInEditor` utility might not even be required and can be removed entirely, since the block's edit function never runs outside the editor. 